### PR TITLE
Misc. typos

### DIFF
--- a/BackTangent.py
+++ b/BackTangent.py
@@ -1,5 +1,5 @@
 """
-Creates tanget alignment geometry for the Transportation wb
+Creates tangent alignment geometry for the Transportation wb
 """
 from PySide import QtGui
 import FreeCAD as App

--- a/GeometryUtilities.py
+++ b/GeometryUtilities.py
@@ -40,7 +40,7 @@ def _get_pt_of_int(back_tangents):
 
     #test to see if the other point is coincident with
     #the either point on the other back tangent
-    #Equality test must accommodate small floating piont error
+    #Equality test must accommodate small floating point error
     if (other - back_tangents[1].element.EndPoint).Length < 0.00001:
         pt_of_int = other
 
@@ -312,7 +312,7 @@ def get_unconstrained_vertices(sketch_object, geometry_container):
     vertices = [True, True]
     falses = [False, False]
 
-    #iterate the constraints, looking for contraints which are attached
+    #iterate the constraints, looking for constraints which are attached
     #to the passed geometry.  Set the corresponding vertex index to False
     for constraint in sketch_object.Constraints:
 

--- a/Tangent.py
+++ b/Tangent.py
@@ -1,5 +1,5 @@
 """
-Creates tanget alignment geometry for the Transportation wb
+Creates tangent alignment geometry for the Transportation wb
 """
 
 from PySide import QtGui
@@ -45,7 +45,7 @@ class Tangent():
         #validate, ensuring no inappropriate constraints
         selection = self._validate_selection()
         
-        #result from an invalid selction
+        #result from an invalid selection
         if selection == None:
             return
 
@@ -78,7 +78,7 @@ class Tangent():
 
         print self.sketch.Geometry[new_index]
 
-        #tangentailly constrain the tangent to curve endpionts and
+        #tangentially constrain the tangent to curve endpoints and
         #coincidentally constrain to back tangent end points
         self._attach_tangent(new_index, end_points)
 
@@ -97,7 +97,7 @@ class Tangent():
         index - index of the back tangent
 
         constraints - A list of ElementContainers containing the constraint
-        object and it's index
+        object and its index
 
         Returns:
 
@@ -231,7 +231,7 @@ class Tangent():
         Iterates the constraints and returns a list of the
         geometry which is attached to the selection.
 
-        Arguements:
+        Arguments:
 
         selection - the selected back tangent (GeometryContainer)
         constraints - List of Sketcher::Constraints attached to back tangent


### PR DESCRIPTION
+ would you consider changing the Vertexes array to Vertices ?
```
./BackTangent.py:67: Vertexes  ==> Vertices
./Tangent.py:174: Vertexes  ==> Vertices
./Tangent.py:179: Vertexes  ==> Vertices
./Tangent.py:181: Vertexes  ==> Vertices
./Tangent.py:222: Vertexes  ==> Vertices
./Tangent.py:223: Vertexes  ==> Vertices
./Tangent.py:298: Vertexes  ==> Vertices
./Tangent.py:299: Vertexes  ==> Vertices
./Tangent.py:301: Vertexes  ==> Vertices
./Tangent.py:302: Vertexes  ==> Vertices
```