### PR TITLE
Typo and whitespace fixes

### DIFF
--- a/BackTangent.py
+++ b/BackTangent.py
@@ -18,7 +18,7 @@ class BackTangent():
         Icon resources.
         """
         return {'Pixmap'  : 'My_Command_Icon',
-                'Accel' : "Shift+B",
+                'Accel'   : "Shift+B",
                 'MenuText': "Back Tangent",
                 'ToolTip' : "Add a back tangent",
                 'CmdType' : "ForEdit"}
@@ -87,7 +87,7 @@ class BackTangent():
 
         QtGui.QMessageBox.critical(None, title, message)
 
-        
+
         #validate the selection, returning if invalid
         #selected_geometry = self._getSelection()
 

--- a/Curve1.py
+++ b/Curve1.py
@@ -21,7 +21,7 @@ class Curve1():
         icon_path += "/icons/one_center_curve.svg"
 
         return {'Pixmap'  : icon_path,
-                'Accel' : "Shift+1",
+                'Accel'   : "Shift+1",
                 'MenuText': "One-Center Curve",
                 'ToolTip' : "Add a one-center curve",
                 'CmdType' : "For Edit"}
@@ -46,7 +46,7 @@ class Curve1():
 
         #swap back tangents if they were swapped in the arc computation
         if result[1] != 0:
-   
+
             x = back_tangents[0]
             back_tangents[0] = back_tangents[1]
             back_tangents[1] = x
@@ -129,7 +129,7 @@ class Curve1():
             return selection
 
         self._notify_error("")
-        
+
         return None
 
     def _notify_error(self, error_type):
@@ -146,4 +146,4 @@ class Curve1():
 
         QtGui.QMessageBox.critical(None, title, message)
 
-Gui.addCommand('Curve1',Curve1()) 
+Gui.addCommand('Curve1',Curve1())

--- a/Curve2.py
+++ b/Curve2.py
@@ -5,7 +5,7 @@ class Curve2():
 
     def GetResources(self):
         return {'Pixmap'  : 'My_Command_Icon', # the name of a svg file available in the resources
-                'Accel' : "Shift+2", # a default shortcut (optional)
+                'Accel'   : "Shift+2", # a default shortcut (optional)
                 'MenuText': "Two-Center Curve",
                 'ToolTip' : "Add a two-center curve"}
 
@@ -16,4 +16,4 @@ class Curve2():
     def IsActive(self):
         return FreeCADGui.ActiveDocument != None
 
-FreeCADGui.addCommand('Curve2',Curve2()) 
+FreeCADGui.addCommand('Curve2',Curve2())

--- a/Curve3.py
+++ b/Curve3.py
@@ -5,7 +5,7 @@ class Curve3():
 
     def GetResources(self):
         return {'Pixmap'  : 'My_Command_Icon', # the name of a svg file available in the resources
-                'Accel' : "Shift+3", # a default shortcut (optional)
+                'Accel'   : "Shift+3", # a default shortcut (optional)
                 'MenuText': "Three-Center Curve",
                 'ToolTip' : "Add a three-center curve"}
 
@@ -16,4 +16,4 @@ class Curve3():
     def IsActive(self):
         return FreeCADGui.ActiveDocument != None
 
-FreeCADGui.addCommand('Curve3',Curve3()) 
+FreeCADGui.addCommand('Curve3',Curve3())

--- a/CurveSpiral.py
+++ b/CurveSpiral.py
@@ -5,7 +5,7 @@ class CurveSpiral():
 
     def GetResources(self):
         return {'Pixmap'  : 'My_Command_Icon', # the name of a svg file available in the resources
-                'Accel' : "Shift+S", # a default shortcut (optional)
+                'Accel'   : "Shift+S", # a default shortcut (optional)
                 'MenuText': "Spiral Curve",
                 'ToolTip' : "Add a spiral curve"}
 
@@ -16,4 +16,4 @@ class CurveSpiral():
     def IsActive(self):
         return FreeCADGui.ActiveDocument <> None
 
-FreeCADGui.addCommand('CurveSpiral',CurveSpiral()) 
+FreeCADGui.addCommand('CurveSpiral',CurveSpiral())

--- a/GeometryUtilities.py
+++ b/GeometryUtilities.py
@@ -137,7 +137,7 @@ def _compare_vectors(lhs, rhs):
     """
     Compares the length of two vectors.  If the length
     is less than 0.00001 (1 * 10^-5), they are equivalent.
-    Retruns:
+    Returns:
     0 - equivalent
     -1 - lhs < rhs
     1 - lhs > rhs

--- a/InitGui.py
+++ b/InitGui.py
@@ -348,7 +348,7 @@ class TransportationWorkbench (Workbench):
         for t in self.toolbars:
             self.appendToolbar(t[0], t[1])
 
-        # create menues
+        # create menus
         menues = {}
         ml = []
         for _t in FreeCAD.tcmdsTransportation:

--- a/NewAlignment.py
+++ b/NewAlignment.py
@@ -8,13 +8,13 @@ import os
 class NewAlignment():
 
     def GetResources(self):
-    
+
         icon_path = os.path.dirname(os.path.abspath(__file__))
 
         icon_path += "/icons/new_alignment.svg"
 
         return {'Pixmap'  : icon_path,
-                'Accel' : "Shift+N",
+                'Accel'   : "Shift+N",
                 'MenuText': "New Alignment",
                 'ToolTip' : "Create a new alignment and make it active",
                 'CmdType' : "ForEdit"}
@@ -40,7 +40,7 @@ class NewAlignment():
 
     def IsActive(self):
         return True
-    
+
     def _attach_handlers(self):
         Gui.ActiveDocument.ActiveView.addDraggable
     def _set_camera(self, height):
@@ -70,7 +70,7 @@ class NewAlignment():
             sketchName="Unnamed_Alignment",
             clientList=['Alignment'])
 
-        return fbs        
+        return fbs
 
     def _add_true_north(self):
 

--- a/Tangent.py
+++ b/Tangent.py
@@ -27,7 +27,7 @@ class Tangent():
         icon_path += "/icons/tangent.svg"
 
         return {'Pixmap'  : icon_path,
-                'Accel' : "Shift+T",
+                'Accel'   : "Shift+T",
                 'MenuText': "Tangent",
                 'ToolTip' : "Add a tangent",
                 'CmdType' : "ForEdit"}
@@ -44,7 +44,7 @@ class Tangent():
 
         #validate, ensuring no inappropriate constraints
         selection = self._validate_selection()
-        
+
         #result from an invalid selection
         if selection == None:
             return
@@ -89,7 +89,7 @@ class Tangent():
 
     def _replace_curve_constraints(self, index, constraints):
         """
-        Replaces tangent constraints on attached curves with 
+        Replaces tangent constraints on attached curves with
         coincident-to-object constraints
 
         Arguments:
@@ -204,7 +204,7 @@ class Tangent():
             print (constraint)
 
             self.sketch.addConstraint(constraint)
-            
+
             App.ActiveDocument.recompute()
 
         return
@@ -237,7 +237,7 @@ class Tangent():
 
         Returns:
 
-        list of geometry / endoint pairs
+        list of geometry / endpoint pairs
         """
 
         attached = []
@@ -317,12 +317,12 @@ class Tangent():
                         continue
                     else:
                         is_reversed = (direction != result)
-                
+
                     if not is_reversed:
                         end_point = [index, i]
                         end_points.append(end_point)
                         break
-                
+
                 if len(end_points) == 2:
                     break
 
@@ -458,7 +458,7 @@ class Tangent():
 
         elif error_type == "Invalid_Attached_Geometry":
             message = "Attached elements are not curves."
-            
+
         QtGui.QMessageBox.critical(None, title, message)
 
         return

--- a/feedbacksketch.py
+++ b/feedbacksketch.py
@@ -240,7 +240,7 @@ class FeedbackSketch(FeaturePython):
                     try:
                         changed[gets]
                         #if valwar == val_cgi:
-                        if debug: print ("stopp change")
+                        if debug: print ("stop change")
                         changed[gets]=2
                     except:
                         changed[gets]=0
@@ -676,4 +676,3 @@ def run_createFBS_with_three_Clients():
     fbs.activeClientA=True
     fbs.activeClientB=True
     fbs.activeClientC=True
-

--- a/transportationwb/beziersketch.py
+++ b/transportationwb/beziersketch.py
@@ -21,8 +21,8 @@ from PySide import QtCore
 from say import sayexc
 
 '''
-# kofig sketcher 
-# see 
+# kofig sketcher
+# see
 hGrpsk = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Sketcher/General")
 
 hGrpsk.GetBool("BSplineDegreeVisible")
@@ -127,7 +127,7 @@ def clearReportView(name):
 
 
 class BezierSketch(FeaturePython):
-	'''Sketch Object with Python for Bezier Curve''' 
+	'''Sketch Object with Python for Bezier Curve'''
 
 	##\cond
 	def __init__(self, obj, icon='/home/thomas/.FreeCAD/Mod/freecad-nurbs/icons/draw.svg'):
@@ -146,10 +146,10 @@ class BezierSketch(FeaturePython):
 		obj.addProperty("App::PropertyLink",'aSketch', )
 		obj.addProperty("App::PropertyLink",'bSketch', )
 		ViewProvider(obj.ViewObject)
-		
+
 		obj.aTangential=True
 		obj.bTangential=True
-		
+
 	##\endcond
 
 
@@ -204,9 +204,9 @@ class BezierSketch(FeaturePython):
 				if obj.bSketch <>None:
 
 					if obj.bTangential:
-						
+
 						obj.setDriving(63,True)
-						
+
 						#obj.setDatum('Barc',(180+obj.bSketch.getDatum('Aarc').Value)*np.pi/180)
 						vn=(-obj.bSketch.getDatum('Aarc').Value)*np.pi/180+np.pi*0.5
 
@@ -315,10 +315,12 @@ class BezierSketch(FeaturePython):
 
 
 def combineSketches():
-	'''creates a BsplineCurve which is the combination of a xy bspline curve A and a xz bspline curve B.
-	both curves must have the same count of poles  and the correspondig poles must have the same x coordinate. The projections of the resulting curve and the A curve to xy plane are the same.
+	'''
+	Creates a BsplineCurve which is the combination of a xy bspline curve A and a xz bspline curve B.
+	Both curves must have the same count of poles and the corresponding poles must have the same x coordinate.
+	The projections of the resulting curve and the A curve to xy plane are the same.
 	The projections of the resulting curve and the B curve to xz plane are the same too.
-	the method works only for simple BSpline curves.
+	The method works only for simple BSpline curves.
 	'''
 
 	[ac,bc]=Gui.Selection.getSelection()
@@ -355,11 +357,11 @@ def createbezier(sk):
 
 
 	sk.addGeometry(Part.Circle(pts[0],App.Vector(0,0,1),10),True)
-	sk.addConstraint(Sketcher.Constraint('Radius',0,10.000000)) 
+	sk.addConstraint(Sketcher.Constraint('Radius',0,10.000000))
 
 	for i in range(1,7):
 		sk.addGeometry(Part.Circle(pts[i],App.Vector(0,0,1),10),True)
-		sk.addConstraint(Sketcher.Constraint('Equal',0,i)) 
+		sk.addConstraint(Sketcher.Constraint('Equal',0,i))
 
 	sk.addGeometry(Part.BSplineCurve(pts,None,None,False,3,None,False),False)
 
@@ -378,38 +380,38 @@ def createbezier(sk):
 	App.ActiveDocument.recompute()
 
 	sk.addGeometry(Part.LineSegment(pts[2],pts[4]),True)
-	sk.addConstraint(Sketcher.Constraint('Coincident',13,1,2,3)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',13,2,4,3)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',13,1,2,3))
+	sk.addConstraint(Sketcher.Constraint('Coincident',13,2,4,3))
 	App.ActiveDocument.recompute()
-	sk.addConstraint(Sketcher.Constraint('PointOnObject',3,3,13)) 
+	sk.addConstraint(Sketcher.Constraint('PointOnObject',3,3,13))
 
 	sk.addGeometry(Part.LineSegment(pts[-1],pts[-2]),True)
 
-	sk.addConstraint(Sketcher.Constraint('Coincident',14,1,6,3)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',14,2,5,3)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',14,1,6,3))
+	sk.addConstraint(Sketcher.Constraint('Coincident',14,2,5,3))
 	App.ActiveDocument.recompute()
 
 	sk.addGeometry(Part.LineSegment(pts[0],pts[1]),True)
 
-	sk.addConstraint(Sketcher.Constraint('Coincident',15,1,0,3)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',15,2,1,3)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',15,1,0,3))
+	sk.addConstraint(Sketcher.Constraint('Coincident',15,2,1,3))
 	App.ActiveDocument.recompute()
 
-	sk.addConstraint(Sketcher.Constraint('DistanceX',0,3,0)) 
-	sk.addConstraint(Sketcher.Constraint('DistanceY',0,3,0)) 
+	sk.addConstraint(Sketcher.Constraint('DistanceX',0,3,0))
+	sk.addConstraint(Sketcher.Constraint('DistanceY',0,3,0))
 	App.ActiveDocument.recompute()
 	sk.renameConstraint(26, u'Ax')
 	App.ActiveDocument.recompute()
 	sk.renameConstraint(27, u'Ay')
-	sk.addConstraint(Sketcher.Constraint('DistanceX',6,3,600)) 
-	sk.addConstraint(Sketcher.Constraint('DistanceY',6,3,000)) 
+	sk.addConstraint(Sketcher.Constraint('DistanceX',6,3,600))
+	sk.addConstraint(Sketcher.Constraint('DistanceY',6,3,000))
 	App.ActiveDocument.recompute()
 	sk.renameConstraint(28, u'Bx')
 	sk.renameConstraint(29, u'By')
 
-	sk.addConstraint(Sketcher.Constraint('Angle',15,2,-1,2,0.5*np.pi)) 
+	sk.addConstraint(Sketcher.Constraint('Angle',15,2,-1,2,0.5*np.pi))
 	sk.renameConstraint(30, u'Aarc')
-	sk.addConstraint(Sketcher.Constraint('Angle',14,2,-1,2,-0.5*np.pi)) 
+	sk.addConstraint(Sketcher.Constraint('Angle',14,2,-1,2,-0.5*np.pi))
 	sk.renameConstraint(31, u'Barc')
 	App.activeDocument().recompute()
 	for i in range(26,32):
@@ -418,9 +420,9 @@ def createbezier(sk):
 	for i in range(32):
 		sk.toggleVirtualSpace(i)
 
-	sk.addConstraint(Sketcher.Constraint('Symmetric',2,3,4,3,3,3)) 
+	sk.addConstraint(Sketcher.Constraint('Symmetric',2,3,4,3,3,3))
 	cc=sk.addGeometry(Part.Circle(App.Vector(600.,0.0,0),App.Vector(0,0,1),20.),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',cc,3,6,3)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',cc,3,6,3))
 
 	App.ActiveDocument.recompute()
 
@@ -439,11 +441,11 @@ def createsimplebezier(sk):
 	pts=pts2
 
 	sk.addGeometry(Part.Circle(pts[0],App.Vector(0,0,1),10),True)
-	sk.addConstraint(Sketcher.Constraint('Radius',0,10.000000)) 
+	sk.addConstraint(Sketcher.Constraint('Radius',0,10.000000))
 
 	for i in range(1,4):
 		sk.addGeometry(Part.Circle(pts[i],App.Vector(0,0,1),10),True)
-		sk.addConstraint(Sketcher.Constraint('Equal',0,i)) 
+		sk.addConstraint(Sketcher.Constraint('Equal',0,i))
 
 	bc=sk.addGeometry(Part.BSplineCurve(pts,None,None,False,3,None,False),False)
 
@@ -460,32 +462,32 @@ def createsimplebezier(sk):
 
 	l=sk.addGeometry(Part.LineSegment(pts[-1],pts[-2]),True)
 
-	sk.addConstraint(Sketcher.Constraint('Coincident',l,1,3,3)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',l,2,2,3)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',l,1,3,3))
+	sk.addConstraint(Sketcher.Constraint('Coincident',l,2,2,3))
 	App.ActiveDocument.recompute()
 
 	l2=sk.addGeometry(Part.LineSegment(pts[0],pts[1]),True)
 
-	sk.addConstraint(Sketcher.Constraint('Coincident',l2,1,0,3)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',l2,2,1,3)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',l2,1,0,3))
+	sk.addConstraint(Sketcher.Constraint('Coincident',l2,2,1,3))
 	App.ActiveDocument.recompute()
 
-	sk.addConstraint(Sketcher.Constraint('DistanceX',0,3,0)) 
-	sk.addConstraint(Sketcher.Constraint('DistanceY',0,3,0)) 
+	sk.addConstraint(Sketcher.Constraint('DistanceX',0,3,0))
+	sk.addConstraint(Sketcher.Constraint('DistanceY',0,3,0))
 	App.ActiveDocument.recompute()
-	
+
 	sk.renameConstraint(14, u'Ax')
 	App.ActiveDocument.recompute()
 	sk.renameConstraint(15, u'Ay')
-	sk.addConstraint(Sketcher.Constraint('DistanceX',3,3,600)) 
-	sk.addConstraint(Sketcher.Constraint('DistanceY',3,3,0)) 
+	sk.addConstraint(Sketcher.Constraint('DistanceX',3,3,600))
+	sk.addConstraint(Sketcher.Constraint('DistanceY',3,3,0))
 	App.ActiveDocument.recompute()
 	sk.renameConstraint(16, u'Bx')
 	sk.renameConstraint(17, u'By')
 
-	sk.addConstraint(Sketcher.Constraint('Angle',l2,2,-1,2,0.5*np.pi)) 
+	sk.addConstraint(Sketcher.Constraint('Angle',l2,2,-1,2,0.5*np.pi))
 	sk.renameConstraint(18, u'Aarc')
-	sk.addConstraint(Sketcher.Constraint('Angle',l,2,-1,2,-0.5*np.pi)) 
+	sk.addConstraint(Sketcher.Constraint('Angle',l,2,-1,2,-0.5*np.pi))
 	sk.renameConstraint(19, u'Barc')
 	App.activeDocument().recompute()
 
@@ -496,7 +498,7 @@ def createsimplebezier(sk):
 		sk.toggleVirtualSpace(i)
 
 	cc=sk.addGeometry(Part.Circle(App.Vector(600.000000,0.000000,0),App.Vector(0,0,1),20.),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',cc,3,3,3)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',cc,3,3,3))
 
 
 
@@ -523,41 +525,41 @@ def ArcSplineSketch(sk):
 	App.ActiveDocument.recompute()
 	sk.addGeometry(Part.LineSegment(pts[0],pts[1]),False)
 	sk.addGeometry(Part.LineSegment(pts[1],pts[2]),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',0,2,1,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',0,2,1,1))
 	App.ActiveDocument.recompute()
 	sk.addGeometry(Part.LineSegment(pts[2],pts[3]),False)
 	# top
-	sk.addConstraint(Sketcher.Constraint('Coincident',1,2,2,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',1,2,2,1))
 	App.ActiveDocument.recompute()
 
 	sk.addGeometry(Part.LineSegment(pts[3],pts[4]),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',2,2,3,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',2,2,3,1))
 	App.ActiveDocument.recompute()
 	sk.addGeometry(Part.LineSegment(pts[4],pts[5]),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',3,2,4,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',3,2,4,1))
 	App.ActiveDocument.recompute()
 	App.ActiveDocument.recompute()
 	sk.addGeometry(Part.LineSegment(pts[5],pts[0]),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',4,2,5,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',4,2,5,1))
 
-	sk.addConstraint(Sketcher.Constraint('Coincident',5,2,0,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',5,2,0,1))
 	App.ActiveDocument.recompute()
 
 
 	#breite
 
-	sk.addConstraint(Sketcher.Constraint('Perpendicular',5,0)) 
+	sk.addConstraint(Sketcher.Constraint('Perpendicular',5,0))
 	App.ActiveDocument.recompute()
-	sk.addConstraint(Sketcher.Constraint('Perpendicular',4,3)) 
+	sk.addConstraint(Sketcher.Constraint('Perpendicular',4,3))
 	App.ActiveDocument.recompute()
 
-	sk.addConstraint(Sketcher.Constraint('Equal',5,4)) 
+	sk.addConstraint(Sketcher.Constraint('Equal',5,4))
 	App.ActiveDocument.recompute()
-	sk.addConstraint(Sketcher.Constraint('Equal',0,3)) 
+	sk.addConstraint(Sketcher.Constraint('Equal',0,3))
 	App.ActiveDocument.recompute()
 	App.ActiveDocument.recompute()
-	sk.addConstraint(Sketcher.Constraint('PointOnObject',1,2,0)) 
-	sk.addConstraint(Sketcher.Constraint('PointOnObject',1,2,3)) 
+	sk.addConstraint(Sketcher.Constraint('PointOnObject',1,2,0))
+	sk.addConstraint(Sketcher.Constraint('PointOnObject',1,2,3))
 
 	App.ActiveDocument.recompute()
 	App.ActiveDocument.recompute()
@@ -566,17 +568,17 @@ def ArcSplineSketch(sk):
 
 
 	sk.addGeometry(Part.Circle(pts[0],App.Vector(0,0,1),10),True)
-	sk.addConstraint(Sketcher.Constraint('Coincident',6,3,0,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',6,3,0,1))
 	sk.addGeometry(Part.Circle(pts[1],App.Vector(0,0,1),10),True)
-	sk.addConstraint(Sketcher.Constraint('Radius',6,10.000000)) 
-	sk.addConstraint(Sketcher.Constraint('Equal',6,7)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',7,3,0,2)) 
+	sk.addConstraint(Sketcher.Constraint('Radius',6,10.000000))
+	sk.addConstraint(Sketcher.Constraint('Equal',6,7))
+	sk.addConstraint(Sketcher.Constraint('Coincident',7,3,0,2))
 	sk.addGeometry(Part.Circle(pts[3],App.Vector(0,0,1),10),True)
-	sk.addConstraint(Sketcher.Constraint('Equal',6,8)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',8,3,2,2)) 
+	sk.addConstraint(Sketcher.Constraint('Equal',6,8))
+	sk.addConstraint(Sketcher.Constraint('Coincident',8,3,2,2))
 	sk.addGeometry(Part.Circle(pts[4],App.Vector(0,0,1),10),True)
-	sk.addConstraint(Sketcher.Constraint('Equal',6,9)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',9,3,3,2)) 
+	sk.addConstraint(Sketcher.Constraint('Equal',6,9))
+	sk.addConstraint(Sketcher.Constraint('Coincident',9,3,3,2))
 	sk.addGeometry(Part.BSplineCurve([pts[0],pts[1],pts[3],pts[4]],None,None,False,3,None,False),False)
 
 	conList = []
@@ -590,14 +592,14 @@ def ArcSplineSketch(sk):
 	App.ActiveDocument.recompute()
 
 
-	sk.addConstraint(Sketcher.Constraint('DistanceX',0,1,pts[0].x)) 
-	sk.addConstraint(Sketcher.Constraint('DistanceY',0,1,pts[0].y)) 
+	sk.addConstraint(Sketcher.Constraint('DistanceX',0,1,pts[0].x))
+	sk.addConstraint(Sketcher.Constraint('DistanceY',0,1,pts[0].y))
 	App.ActiveDocument.recompute()
-	sk.addConstraint(Sketcher.Constraint('DistanceX',3,2,pts[4].x)) 
-	sk.addConstraint(Sketcher.Constraint('DistanceY',3,2,pts[4].y)) 
+	sk.addConstraint(Sketcher.Constraint('DistanceX',3,2,pts[4].x))
+	sk.addConstraint(Sketcher.Constraint('DistanceY',3,2,pts[4].y))
 	App.ActiveDocument.recompute()
 
-	sk.addConstraint(Sketcher.Constraint('Angle',-1,1,0,1,0.25*np.pi)) 
+	sk.addConstraint(Sketcher.Constraint('Angle',-1,1,0,1,0.25*np.pi))
 
 	App.ActiveDocument.recompute()
 
@@ -612,43 +614,43 @@ def ArcSplineSketch(sk):
 	App.ActiveDocument.recompute()
 	sk.addGeometry(Part.LineSegment(pts[0],pts[1]),False)
 	sk.addGeometry(Part.LineSegment(pts[1],pts[2]),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+0,2,gc+1,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+0,2,gc+1,1))
 	App.ActiveDocument.recompute()
 	sk.addGeometry(Part.LineSegment(pts[2],pts[3]),False)
 	# top
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+1,2,gc+2,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+1,2,gc+2,1))
 	App.ActiveDocument.recompute()
 
 
 	sk.addGeometry(Part.LineSegment(pts[3],pts[4]),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+2,2,gc+3,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+2,2,gc+3,1))
 	App.ActiveDocument.recompute()
 	sk.addGeometry(Part.LineSegment(pts[4],pts[5]),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+3,2,gc+4,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+3,2,gc+4,1))
 	App.ActiveDocument.recompute()
 	App.ActiveDocument.recompute()
 	sk.addGeometry(Part.LineSegment(pts[5],pts[0]),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+4,2,gc+5,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+4,2,gc+5,1))
 
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+5,2,gc+0,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+5,2,gc+0,1))
 	App.ActiveDocument.recompute()
 
 
 	#breite
 
-	sk.addConstraint(Sketcher.Constraint('Perpendicular',gc+5,gc+0)) 
+	sk.addConstraint(Sketcher.Constraint('Perpendicular',gc+5,gc+0))
 	App.ActiveDocument.recompute()
-	sk.addConstraint(Sketcher.Constraint('Perpendicular',gc+4,gc+3)) 
+	sk.addConstraint(Sketcher.Constraint('Perpendicular',gc+4,gc+3))
 	App.ActiveDocument.recompute()
 
 
-	sk.addConstraint(Sketcher.Constraint('Equal',gc+5,gc+4)) 
+	sk.addConstraint(Sketcher.Constraint('Equal',gc+5,gc+4))
 	App.ActiveDocument.recompute()
-	sk.addConstraint(Sketcher.Constraint('Equal',gc+0,gc+3)) 
+	sk.addConstraint(Sketcher.Constraint('Equal',gc+0,gc+3))
 	App.ActiveDocument.recompute()
 	App.ActiveDocument.recompute()
-	sk.addConstraint(Sketcher.Constraint('PointOnObject',gc+1,2,gc+0)) 
-	sk.addConstraint(Sketcher.Constraint('PointOnObject',gc+1,2,gc+3)) 
+	sk.addConstraint(Sketcher.Constraint('PointOnObject',gc+1,2,gc+0))
+	sk.addConstraint(Sketcher.Constraint('PointOnObject',gc+1,2,gc+3))
 
 	App.ActiveDocument.recompute()
 	App.ActiveDocument.recompute()
@@ -657,22 +659,22 @@ def ArcSplineSketch(sk):
 
 	sk.addGeometry(Part.Circle(pts[0],App.Vector(0,0,1),10),True)
 
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+6,3,gc+0,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+6,3,gc+0,1))
 	sk.addGeometry(Part.Circle(pts[1],App.Vector(0,0,1),10),True)
-#	sk.addConstraint(Sketcher.Constraint('Radius',gc+6,10.000000)) 
-	sk.addConstraint(Sketcher.Constraint('Equal',6,gc+6)) 
+#	sk.addConstraint(Sketcher.Constraint('Radius',gc+6,10.000000))
+	sk.addConstraint(Sketcher.Constraint('Equal',6,gc+6))
 
-	sk.addConstraint(Sketcher.Constraint('Equal',gc+6,gc+7)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+7,3,gc+0,2)) 
+	sk.addConstraint(Sketcher.Constraint('Equal',gc+6,gc+7))
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+7,3,gc+0,2))
 	sk.addGeometry(Part.Circle(pts[3],App.Vector(0,0,1),10),True)
-	sk.addConstraint(Sketcher.Constraint('Equal',gc+6,gc+8)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+8,3,gc+2,2)) 
+	sk.addConstraint(Sketcher.Constraint('Equal',gc+6,gc+8))
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+8,3,gc+2,2))
 	sk.addGeometry(Part.Circle(pts[4],App.Vector(0,0,1),10),True)
-	sk.addConstraint(Sketcher.Constraint('Equal',gc+6,gc+9)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',gc+9,3,gc+3,2)) 
+	sk.addConstraint(Sketcher.Constraint('Equal',gc+6,gc+9))
+	sk.addConstraint(Sketcher.Constraint('Coincident',gc+9,3,gc+3,2))
 	sk.addGeometry(Part.BSplineCurve([pts[0],pts[1],pts[3],pts[4]],None,None,False,3,None,False),False)
 
-	
+
 	conList = []
 	conList.append(Sketcher.Constraint('InternalAlignment:Sketcher::BSplineControlPoint',gc+6,3,gc+10,0))
 	conList.append(Sketcher.Constraint('InternalAlignment:Sketcher::BSplineControlPoint',gc+7,3,gc+10,1))
@@ -684,24 +686,24 @@ def ArcSplineSketch(sk):
 	App.ActiveDocument.recompute()
 
 
-	sk.addConstraint(Sketcher.Constraint('PointOnObject',16,2,3)) 
-	sk.addConstraint(Sketcher.Constraint('PointOnObject',15,2,3)) 
+	sk.addConstraint(Sketcher.Constraint('PointOnObject',16,2,3))
+	sk.addConstraint(Sketcher.Constraint('PointOnObject',15,2,3))
 
 
 	la=sk.addGeometry(Part.LineSegment(pts[0],pts[1]),False)
-	sk.addConstraint(Sketcher.Constraint('Coincident',la,1,3,2)) 
-	sk.addConstraint(Sketcher.Constraint('Coincident',la,2,gc+4,1)) 
+	sk.addConstraint(Sketcher.Constraint('Coincident',la,1,3,2))
+	sk.addConstraint(Sketcher.Constraint('Coincident',la,2,gc+4,1))
 
 
-	sk.addConstraint(Sketcher.Constraint('DistanceX',gc+0,1,pts[0].x)) 
-	sk.addConstraint(Sketcher.Constraint('DistanceY',gc+0,1,pts[0].y)) 
+	sk.addConstraint(Sketcher.Constraint('DistanceX',gc+0,1,pts[0].x))
+	sk.addConstraint(Sketcher.Constraint('DistanceY',gc+0,1,pts[0].y))
 	App.ActiveDocument.recompute()
-#	sk.addConstraint(Sketcher.Constraint('DistanceX',3,2,pts[4].x)) 
-#	sk.addConstraint(Sketcher.Constraint('DistanceY',3,2,pts[4].y)) 
+#	sk.addConstraint(Sketcher.Constraint('DistanceX',3,2,pts[4].x))
+#	sk.addConstraint(Sketcher.Constraint('DistanceY',3,2,pts[4].y))
 #	App.ActiveDocument.recompute()
 
 	for i in [1,2,3,4,5,14,15,16,17,18]:
-		sk.toggleConstruction(i) 
+		sk.toggleConstruction(i)
 		pass
 	App.ActiveDocument.recompute()
 
@@ -715,12 +717,12 @@ def ArcSplineSketch(sk):
 	App.ActiveDocument.recompute()
 #	App.ActiveDocument.recompute()
 
-	sk.toggleDriving(29) 
-	sk.toggleDriving(28) 
+	sk.toggleDriving(29)
+	sk.toggleDriving(28)
 
-#	aa=sk.addConstraint(Sketcher.Constraint('Angle',13,-0.5*np.pi)) 
+#	aa=sk.addConstraint(Sketcher.Constraint('Angle',13,-0.5*np.pi))
 
-	aa=sk.addConstraint(Sketcher.Constraint('Angle',14,2,-1,2, -0.56)) 
+	aa=sk.addConstraint(Sketcher.Constraint('Angle',14,2,-1,2, -0.56))
 	sk.renameConstraint(63, u'Barc')
 
 #--------------

--- a/transportationwb/corridor/Alignment.py
+++ b/transportationwb/corridor/Alignment.py
@@ -242,7 +242,7 @@ class _ViewProviderAlignment:
         """
         Handle individual property changes
         """
-        print ("Box culvert View proeprty " + prop + " changed")
+        print ("Box culvert View property " + prop + " changed")
         pass
 
     def getIcon(self):

--- a/transportationwb/corridor/Cell.py
+++ b/transportationwb/corridor/Cell.py
@@ -24,7 +24,7 @@
 #************************************************************************
 
 """
-Cell feature generates a 3D cell, consiting of a sketch swept along a baseline
+Cell feature generates a 3D cell, consisting of a sketch swept along a baseline
 """
 __title__ = "Cell.py"
 __author__ = "Joel Graff"

--- a/transportationwb/drainage/EndWall.py
+++ b/transportationwb/drainage/EndWall.py
@@ -50,7 +50,7 @@ def validate_selection():
     selected = Gui.Selection.getSelectionEx()[0]
 
     if structure.TypeId != 'PartDesign::AdditivePipe':
-        print ("Invaild structure selected (requires PartDesign::AdditivePipe")
+        print ("Invalid structure selected (requires PartDesign::AdditivePipe")
         return None
 
     if len(selected.SubElementNames) != 2:

--- a/transportationwb/drainage/box_culvert_tools.py
+++ b/transportationwb/drainage/box_culvert_tools.py
@@ -47,7 +47,7 @@ def get_body():
     body = Gui.Selection.getSelection()[0].getParentGeoFeatureGroup()
 
     if body.TypeId != 'PartDesign::Body':
-        print("invalid object heirarchy.  Body not found.")
+        print("invalid object hierarchy.  Body not found.")
         return None
 
     return body

--- a/transportationwb/labeltools.py
+++ b/transportationwb/labeltools.py
@@ -127,7 +127,7 @@ def createLabel(obj, ref, ctext):
 
 def createLabels(f, e, v):
     '''creates labels for faces, edges,vertexes of selected objects
-    the flags f,e,v indicate which componentes should be labeled'''
+    the flags f,e,v indicate which components should be labeled'''
 
     for obj in Gui.Selection.getSelection():
 

--- a/transportationwb/miki_g.py
+++ b/transportationwb/miki_g.py
@@ -52,7 +52,7 @@ def getComboView(mw):
 def ComboViewShowWidget(widget, tabMode=False):
 	'''create a tab widget inside the combo view'''
 
-	# stopp to default
+	# stop to default
 	if not tabMode:
 		widget.show()
 		return widget
@@ -137,7 +137,7 @@ def run_magic(p,c):
 
 
 def DockWidget(title=''):
-	'''create a dock widget in a gibes dock container window'''
+	'''create a dock widget in a given dock container window'''
 
 	t = QtGui.QLabel("my widget")
 	w = MikiDockWidget(t, "transport WB")
@@ -257,7 +257,7 @@ def VerticalGroup(title=''):
 	w.setTitle("vertical layout group")
 	layout = QtGui.QVBoxLayout()
 	layout.setAlignment(QtCore.Qt.AlignLeft)
-#	label = QtGui.QLabel("HUWAS2")   
+#	label = QtGui.QLabel("HUWAS2")
 #	layout.addWidget(label)
 #	verticalSpacer = QtGui.QSpacerItem(10, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
 #	layout.addItem(verticalSpacer)
@@ -327,12 +327,12 @@ class Miki(object):
 
 	def __init__(self):
 		## objects of huhu
-		self.objects = [] 
+		self.objects = []
 		## the widget of the generated Qt sctructure
 		self.widget = None
-		## the ids of the input/output sub-widgets 
+		## the ids of the input/output sub-widgets
 		self.ids = {}
-		
+
 		##\cond
 		self.anchors = {}
 		self.indents = []
@@ -568,7 +568,7 @@ class Miki(object):
 							print ("nicht implementierter typ  Ayy")
 							print ([v,cn])
 							print (l)
-							ex='' 
+							ex=''
 							print ("nicht implementierter typ")
 
 						exec(ex)
@@ -883,7 +883,7 @@ class MikiDockWidget(QtGui.QDockWidget):
 
 
 def getMainWindowByName(name):
-	'''returns a main window of a given Title, 
+	'''returns a main window of a given Title,
 	if there is no such main window an new main window is created'''
 
 	if name == 'FreeCAD':
@@ -997,7 +997,7 @@ def createMikiGui(layout, app):
 	appi.root = miki
 
 	rca = miki.run(layout)
-	
+
 	return rca
 
 
@@ -1144,7 +1144,7 @@ VerticalLayoutTab:
 			QtGui.QPushButton:
 		QtGui.QPushButton:
 	VerticalGroup:
-	setSpacer: 
+	setSpacer:
 	'''
 
 

--- a/transportationwb/property_creator.ui
+++ b/transportationwb/property_creator.ui
@@ -111,7 +111,7 @@
        </sizepolicy>
       </property>
       <property name="text">
-       <string>Deafult Value</string>
+       <string>Default Value</string>
       </property>
       <property name="textFormat">
        <enum>Qt::PlainText</enum>

--- a/transportationwb/usecases.md
+++ b/transportationwb/usecases.md
@@ -3,23 +3,23 @@ Use Cases
 
 ## To do
 - [ ] collect use cases
-- [ ] describe and ilustrate them
+- [ ] describe and illustrate them
 - [ ] connect to details of the used dialogs and interaction videos
 
 # Import Data into a project
 
-The simplest way to get some real data into the project is 
+The simplest way to get some real data into the project is
 the use of the geodat workbench to import openstreetmap data.
 
 For testing purposes there are 3 location in the Demo menu.
 Eichleite is a street with strong curves and a height difference of near 100 meters.
-It is an intersting real testcase for swept pathes. The street is forbitten for long vehicles.
+It is an interesting real testcase for swept paths. The street is forbidden for long vehicles.
 
-After calling the methods some groups are created. The GRP pathes contains all pathes found,
-the GRP highways contains street objects. 
-The center of the area square is the origin and corresponds to the lat lon values used in the scripts.
+After calling the methods some groups are created. The GRP paths contains all paths found,
+the GRP highways contains street objects.
+The center of the area square is the origin and corresponds to the lat long values used in the scripts.
 
-For other locations use the geodat workbench  "Import OSM Map". 
+For other locations use the geodat workbench's "Import OSM Map". 
 
 ## import terrain
 

--- a/transportationwb/vehicle/__init__.py
+++ b/transportationwb/vehicle/__init__.py
@@ -1,5 +1,5 @@
 '''simulation of traffic
-swept pathes, traffic flow, traffic simulator etc. 
+swept paths, traffic flow, traffic simulator etc. 
 '''
 
 import transportationwb


### PR DESCRIPTION
Found via `codespell -q 3 -D ../uber-dictionary.txt -L vertexes,modul,ue`